### PR TITLE
add default dispatch settings to projections

### DIFF
--- a/.projections.json
+++ b/.projections.json
@@ -1,6 +1,7 @@
 {
   "_posts/*.md": {
     "type": "post",
+    "dispatch": "bundle exec jekyll serve --watch --future",
     "template": [
       "---",
       "layout: post",
@@ -12,7 +13,7 @@
       "  email:",
       "  url:",
       "  github:",
-      "---",
+      "---"
     ]
   }
 }


### PR DESCRIPTION
now, running `:Dispatch` or `:Dispatch!` without arguments will default
to running `bundle exec jekyll serve --watch --future` instead of
`:Make`.